### PR TITLE
Fixed hiding text

### DIFF
--- a/src/scripts/content-script-youtube-rate-buttons.ts
+++ b/src/scripts/content-script-youtube-rate-buttons.ts
@@ -3,7 +3,6 @@
 import { svgs } from "./icons";
 
 const gSelBezel = ".ytp-bezel";
-const gSelBezelIcon = ".ytp-bezel-icon";
 let gLastRating: "like" | "dislike";
 
 function getIsActive(elButton: HTMLElement): boolean {
@@ -43,9 +42,17 @@ function showIndicator(isRated = true): void {
   if (!getIsShorts()) {
     const elBezelContainer = getBezelContainer();
     const elBezel = elBezelContainer.querySelector<HTMLDivElement>(gSelBezel);
-    const elBezelIcon = elBezelContainer.querySelector<HTMLDivElement>(gSelBezelIcon);
+    const elBezelIcon = elBezelContainer.querySelector<HTMLDivElement>(".ytp-bezel-icon");
+    const elBezelTextWrapperContainer = elBezelContainer.querySelector<HTMLDivElement>(".ytp-bezel-text-wrapper").parentElement;
+
     const iconName = isRated ? gLastRating : `un${gLastRating}`;
     elBezelIcon.innerHTML = svgs[iconName];
+
+    const classNameHider = "ytp-bezel-text-hide";
+    if (!elBezelTextWrapperContainer.classList.contains(classNameHider)) {
+      elBezelTextWrapperContainer.classList.add(classNameHider);
+    }
+
     elBezelContainer.style.display = "";
     elBezel.ariaLabel = "";
   }


### PR DESCRIPTION
If the user pressed the up/down keys to change the volume, then in addition to displaying the volume icon, it also shows the current volume percentage as text
Then, if the user rates/un-rates the video, it will show as such:
![msedge_2022-02-27_13-18-16](https://user-images.githubusercontent.com/6422804/155880371-61936146-c53a-470b-bdce-789399ba9afb.png)

This PR contains a fix for this behavior, such that the text will always be hidden